### PR TITLE
Require implementation file correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require("lib/parallel-batch.js");
+module.exports = require("./lib/parallel-batch.js");


### PR DESCRIPTION
uses relative path for require statement (see diff)
